### PR TITLE
Use real Ynova leads data for pipeline page

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type Lead = {
   year: number;
   energy_value: string;
   invoice_amount: string;
-  status: 'novo' | 'qualificado' | 'proposta' | 'negociacao' | 'fechado';
+  status: string;
   observations?: string;
   consultant_id?: string;
   created_at: string;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -175,7 +175,7 @@ export const createLead = async (leadData: {
   year: number;
   energy_value: number;
   invoice_amount: number;
-  status?: 'novo' | 'qualificado' | 'proposta' | 'negociacao' | 'fechado';
+  status?: string;
   observations?: string;
   has_solar_generation?: boolean;
   solar_generation_type?: string;
@@ -208,7 +208,7 @@ export const updateLead = async (leadId: string, leadData: {
   year?: number;
   energy_value?: number;
   invoice_amount?: number;
-  status?: 'novo' | 'qualificado' | 'proposta' | 'negociacao' | 'fechado';
+  status?: string;
   observations?: string;
   has_solar_generation?: boolean;
   solar_generation_type?: string;


### PR DESCRIPTION
## Summary
- replace the pipeline status mock implementation with a dynamic build based on the Ynova leads endpoint and JWT authentication
- normalize API payloads to the internal lead structure, translate backend statuses to friendly stage names, and render stages/funnel only when data exists
- relax the lead status typing so downstream features can handle new backend statuses

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d81e55a4ac8327b09f0ba522316e65